### PR TITLE
feat: add CI for tests and configure Jest

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,21 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ "main" ]
+
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        cache: 'npm'
+        
+    - run: npm install
+    - run: npm test

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,3 +1,5 @@
+// `matchMedia` is not available in JSDOM, so we need to mock it out
+// https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 global.matchMedia =
   global.matchMedia ||
   function () {

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,0 +1,9 @@
+global.matchMedia =
+  global.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener() {},
+      removeListener() {},
+    }
+  }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
   },
   "jest": {
     "preset": "react-native",
-    "prettierPath": null
+    "prettierPath": null,
+    "moduleNameMapper": {
+      "@react-native-templates/(.*)": "<rootDir>/packages/$1/src"
+    }
   },
   "release-it": {
     "git": {

--- a/package.json
+++ b/package.json
@@ -66,11 +66,15 @@
     ]
   },
   "jest": {
-    "preset": "react-native",
+    "testEnvironment": "jsdom",
     "prettierPath": null,
     "moduleNameMapper": {
-      "@react-native-templates/(.*)": "<rootDir>/packages/$1/src"
-    }
+      "@react-native-templates/(.*)": "<rootDir>/packages/$1/src",
+      "^react-native$": "react-native-web"
+    },
+    "setupFiles": [
+      "<rootDir>/jest/setup.js"
+    ]
   },
   "release-it": {
     "git": {

--- a/packages/core/src/__tests__/refs.test.tsx
+++ b/packages/core/src/__tests__/refs.test.tsx
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 import { render } from '@testing-library/react'
 import React from 'react'
 

--- a/packages/core/src/__tests__/template.test.tsx
+++ b/packages/core/src/__tests__/template.test.tsx
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 

--- a/packages/ui-tamagui/src/__tests__/index.test.tsx
+++ b/packages/ui-tamagui/src/__tests__/index.test.tsx
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { BaseTemplate } from '@react-native-templates/core'
 import { config } from '@tamagui/config/v3'
 import { render } from '@testing-library/react'
@@ -40,21 +36,32 @@ it('should render a Tamagui component', () => {
 
   expect(element.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <view
-        style="flex-direction: row;"
+      <span
+        class="t_light is_inversed _dsp_contents"
       >
-        <text
-          accessibilityrole="header"
-          style="color: rgb(23, 23, 23); text-transform: none; font-family: InterBold; letter-spacing: -1.5px; font-size: 44px; line-height: 53; margin: 0px 0px 0px 0px;"
+        <span
+          class=" t_light _dsp_contents is_Theme"
         >
-          Hello
-        </text>
-        <text
-          style="color: rgb(23, 23, 23); font-family: Inter; letter-spacing: 0; font-size: 14px; line-height: 23;"
-        >
-          Welcome to Tamagui!
-        </text>
-      </view>
+          <div
+            class="_dsp-flex _ai-stretch _fd-row _fb-auto _bxs-border-box _pos-relative _mih-0px _miw-0px _fs-0"
+            data-testid="root"
+          >
+            <h1
+              class="is_H1 font_heading _col-675002279 _tt-1440318557 _ff-299667014 _fow-1366436877 _ls-905095908 _fos-1477259397 _lh-1677663454 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
+              data-testid="root.children[0]"
+              role="heading"
+            >
+              Hello
+            </h1>
+            <p
+              class="is_Paragraph font_body _col-675002279 _ff-299667014 _fow-233016140 _ls-167744059 _fos-229441220 _lh-222976573 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
+              data-testid="root.children[1]"
+            >
+              Welcome to Tamagui!
+            </p>
+          </div>
+        </span>
+      </span>
     </DocumentFragment>
   `)
 })


### PR DESCRIPTION
This PR configures `jest` to always run from source and configures Github Action to test it and report. I am unifying testing environment to be web. Before, as you can see from the snapshots, Tamagui was rendering React Native views (and generating warnings about <Text /> not existing in the current environment), despite testing environment being `jsdom`. This is now fixed and unified.